### PR TITLE
Allow "make build curl" usage plus other small makefile changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.dnf
+.system

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,6 @@ install: srpmproc/srpmproc .dnf .system
 clean:
 	rm -rf srpmproc  $(HOME)/rocky 
 
-test:
-	(mkdir -p $(HOME)/rocky && cd $(HOME)/rocky && rockyget curl)
-	(cd $(HOME)/rocky/curl/r8 && rockybuild-notest)
-
-
 # enable makefile to accept argument after command
 #https://stackoverflow.com/questions/6273608/how-to-pass-argument-to-makefile-from-command-line
 
@@ -60,10 +55,18 @@ help:
 	@echo "Available targets are:"
 	@echo "  all                    Default without argument"
 	@echo "  help                   Showing this help "
-	@echo "  install                Install "
+	@echo "  install                Install devtool"
+	@echo "  build  rpm-name        Ex: make build perl "
 	@echo "  clean                  clean myrocky and srpmproc "
 	@echo "  commit {"my message"}  ie, git commit, without or with real commit message"
 	@echo "  status                 ie, git status"
 	@echo "  pull                   ie, git pull"
 	@echo ""
+
+build:
+	(mkdir -p $(HOME)/rocky && cd $(HOME)/rocky && rockyget $(filter-out $@,$(MAKECMDGOALS)))
+	(cd $(HOME)/rocky/$(filter-out $@,$(MAKECMDGOALS))/r8 && rockybuild-notest)
+
+
+
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ commit:
 pull:
 	git pull
 help:
-	@echo "Usage: make <target>"
+	@echo "Usage: make <target> <argument>"
 	@echo
 	@echo "Available targets are:"
 	@echo "  all                    Default without argument"

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,35 @@ install: srpmproc/srpmproc .dnf .system
 
 
 clean:
-	rm -rf srpmproc
+	rm -rf srpmproc  $(HOME)/rocky 
+
+test:
+	(mkdir -p $(HOME)/rocky && cd $(HOME)/rocky && rockyget curl)
+	(cd $(HOME)/rocky/curl/r8 && rockybuild-notest)
+
+
+# enable makefile to accept argument after command
+#https://stackoverflow.com/questions/6273608/how-to-pass-argument-to-makefile-from-command-line
+
+args = `arg="$(filter-out $@,$(MAKECMDGOALS))" && echo $${arg:-${1}}`
+%:
+	@:
+status:
+	git status
+commit:
+	git commit -am "$(call args, Automated commit message without details, Please read the git diff)"  && git push
+pull:
+	git pull
+help:
+	@echo "Usage: make <target>"
+	@echo
+	@echo "Available targets are:"
+	@echo "  all                    Default without argument"
+	@echo "  help                   showing this help "
+	@echo "  install                Install "
+	@echo "  clean                  clean myrocky and srpmproc "
+	@echo "  commit {"my message"}  ie, git commit, without or with real commit message"
+	@echo "  status                 ie, git status"
+	@echo "  pull                   ie, git pull"
+	@echo ""
+

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ help:
 	@echo
 	@echo "Available targets are:"
 	@echo "  all                    Default without argument"
-	@echo "  help                   showing this help "
+	@echo "  help                   Showing this help "
 	@echo "  install                Install "
 	@echo "  clean                  clean myrocky and srpmproc "
 	@echo "  commit {"my message"}  ie, git commit, without or with real commit message"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ From this source directory, run the following commands:
 This installation will automatically install `nginx` and will configure a
 local repository to be run and usable at: /usr/share/nginx/html/repo
 
+Following enable directory browsing of RPMs in /usr/share/nginx/html/repo
+
+```
+#/etc/nginx/nginx.conf
+<snipped>
+   location / {
+              root /usr/share/nginx/html;index index.html;autoindex on;
+              }
+<snipped>	      
+```		      
+
 note: The permissions on this repository are wide open, so please tune if
 you are on a shared system.
 

--- a/bin/rockybuild-notest
+++ b/bin/rockybuild-notest
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -xe
+
+
+createrepo /usr/share/nginx/html/repo
+
+rpmbuild -bs --nodeps --define "%_topdir `pwd`" --define "dist .el8" SPECS/*.spec
+
+touch /tmp/mock-include.tpl
+
+mock --nocheck -r /etc/mock/rocky8.cfg --resultdir=`pwd` SRPMS/*.src.rpm --cleanup-after  "$@"
+
+cp *.rpm SRPMS/*.src.rpm /usr/share/nginx/html/repo/
+
+createrepo /usr/share/nginx/html/repo
+


### PR DESCRIPTION
pls take as many changes as you see fit in this pull.

```
[me@centos8t01 devtools]$ make -n
make: Nothing to be done for 'all'.
[me@centos8t01 devtools]$ make help
Usage: make <target> <argument>

Available targets are:
  all                    Default without argument
  help                   Showing this help
  install                Install devtool
  build  rpm-name        Ex: make build perl
  clean                  clean myrocky and srpmproc
  commit {my message}  ie, git commit, without or with real commit message
  status                 ie, git status
  pull                   ie, git pull

[me@centos8t01 devtools]$
```