### PR TITLE
Update rocky devtools for 9; simplify and add container method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .dnf
 .system
+.go-setup
+srpmproc/

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,85 @@
+FROM golang:1.16 as srpmproc
+ARG srpmproc_version=v0.3.9
+ENV srpmproc_version=$srpmproc_version
+RUN git clone https://github.com/rocky-linux/srpmproc /go/src/github.com/rocky-linux/srpmproc/
+WORKDIR /go/src/github.com/rocky-linux/srpmproc/
+RUN git checkout $srpmproc_version
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o srpmproc ./cmd/srpmproc 
+
+FROM docker.io/neilresf/scratch:minimal as dnf
+RUN microdnf -y upgrade
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/Rocky-PowerTools.repo
+RUN microdnf -y install epel-release
+RUN microdnf -y install rpm-build mock createrepo git-core \
+   autoconf \
+   automake \
+   binutils \
+   bison \
+   flex \
+   gcc \
+   gcc-c++ \
+   gdb \
+   glibc-devel \
+   libtool \
+   make \
+   pkgconf \
+   pkgconf-m4 \
+   pkgconf-pkg-config \
+   redhat-rpm-config \
+   rpm-build \
+   rpm-sign \
+   strace \
+   asciidoc \
+   byacc \
+   ctags \
+   diffstat \
+   elfutils-libelf-devel \
+   git \
+   intltool \
+   jna \
+   ltrace \
+   patchutils \
+   perl-Fedora-VSP \
+   perl-Sys-Syslog \
+   perl-generators \
+   pesign \
+   source-highlight \
+   systemtap \
+   valgrind \
+   valgrind-devel \
+   cmake \
+   expect \
+   rpmdevtools \
+   rpmlint
+
+
+FROM dnf as devtools
+COPY etc_mock/rocky* /etc/mock/
+COPY etc_mock/templates/* /etc/mock/templates/
+COPY bin/* /usr/local/bin/
+RUN chmod 0755 /usr/local/bin/rocky*
+
+
+FROM devtools as base
+COPY --from=srpmproc /go/src/github.com/rocky-linux/srpmproc/srpmproc /usr/local/bin/srpmproc
+ARG user=root
+RUN usermod -a -G mock $user
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+FROM base as prep
+ARG PACKAGE
+ENV PACKAGE=$PACKAGE
+ARG BRANCH
+ENV BRANCH=$BRANCH
+
+#RUN env
+#RUN /entrypoint.sh get
+
+
+FROM prep
+WORKDIR /root/rocky/
+RUN for a in get prep build; do echo "alias $a=rocky$a" >> /root/.bashrc; done
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD ["prep", "build"]

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .PHONY: all
 
-all: .go-setup src/rockymockgen srpmproc/srpmproc modulelist
+all: .go-setup srpmproc/srpmproc
 
 .dnf:
 	sudo dnf -y install epel-release
 	sudo dnf -y groupinstall "Development Tools"
-	sudo dnf -y install golang mock nginx createrepo git
+	sudo dnf -y install golang mock mock-core-configs nginx createrepo git
 	touch .dnf
 
 .system:
@@ -24,29 +24,20 @@ srpmproc:
 
 
 srpmproc/srpmproc: srpmproc
-	cd srpmproc; CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/srpmproc
+	cd srpmproc; GO111MODULE=auto CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/srpmproc
 
 
-src/rockymockgen:
-	go build -o src/rockymockgen src/rockymockgen.go
-
-modulelist:
-	for i in modulefiles/*; do echo "Building list of modular packages: $$i"; go run src/rockyrpmmodules.go < $$i >> modulelist; done
-
-install: srpmproc/srpmproc src/rockymockgen modulelist .dnf .system
-	mkdir -p /etc/rocky/devtools
-	cp -r etc_mock/rocky* /etc/mock/
-	cp -r modulefiles /etc/rocky/devtools/
-	install -m 755 src/rockymockgen /usr/local/bin/
-	install -m 755 srpmproc/srpmproc /usr/local/bin/
+scriptinstall: 
 	install -m 755 bin/* /usr/local/bin/
-	install -m 644 modulelist /etc/rocky/devtools/
+
+install: srpmproc/srpmproc .dnf .system scriptinstall
+	install -m 755 srpmproc/srpmproc /usr/local/bin/
 	test -d /usr/share/nginx/html/repo || mkdir /usr/share/nginx/html/repo
 	chmod 777 /usr/share/nginx/html/repo
 
 
 clean:
-	rm -rf srpmproc modulelist src/rockymockgen
+	rm -rf srpmproc
 
 # enable makefile to accept argument after command
 #https://stackoverflow.com/questions/6273608/how-to-pass-argument-to-makefile-from-command-line

--- a/bin/rockybuild
+++ b/bin/rockybuild
@@ -1,11 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
-NAME="$1"
-BRANCH="$2"
-ARCH=`uname -m`
-MOCKCFG="/etc/mock/rocky-$ARCH.cfg"
+NAME="${1:-$PACKAGE}"
+BRANCH="${2:-${BRANCH:-r8}}"
+ARCH=${ARCH:-$(uname -m)}
+VERSION="${BRANCH:1:1}"
 
-shift
 shift
 
 if [ -z "$NAME" ]; then
@@ -14,76 +13,28 @@ if [ -z "$NAME" ]; then
 fi
 
 
-# SANITY
-if [ ! -d "${HOME}/rocky/rpms/${NAME}" ]; then
-    echo "ERROR: package name is not imported"
-    exit 1
-fi
-if [ -z "$BRANCH" ]; then
-    BRANCHES=`ls -1 ${HOME}/rocky/rpms/${NAME} | wc -l`
-    if [ "$BRANCHES" -eq 1 ]; then
-        BRANCH=`( cd ${HOME}/rocky/rpms/${NAME}/ ; ls -d *)`
-    else
-        echo "ERROR: What branch do you want to build:"
-        ( cd $HOME/rocky/rpms/${NAME}; ls -1 )
-        exit 1
-    fi
-fi
-if [ ! -d "${HOME}/rocky/rpms/${NAME}/${BRANCH}" ]; then
-    echo "This package branch does not exist."
-    exit 255
-fi
-
-
-# MODULARITY
-TMPCFG=`mktemp /tmp/rockybuild-mock-XXXXXXX.cfg`
-cat "$MOCKCFG" > "$TMPCFG"
-
-if [ -n "$1" ]; then
-    FILES=`for MODULE in $@; do
-        if [ -f "/etc/rocky/devtools/modulefiles/$MODULE" ]; then
-            echo -n "/etc/rocky/devtools/modulefiles/$MODULE "
-            echo "Including Module: $MODULE" >&2
-        else
-            echo "WARNING: Could not find module config for: $MODULE" >&2
-        fi
-    done`
-
-    rockymockgen $FILES >> "$TMPCFG"
-    sleep 3
-else
-    STREAM=`echo $BRANCH | sed -e 's/r8-stream-//'`
-    FILES=`grep "^$NAME " /etc/rocky/devtools/modulelist | while read name module stream; do
-        if [ "$STREAM" == "$stream" ]; then
-            if [ -f "/etc/rocky/devtools/modulefiles/$module:$stream" ]; then
-                echo -n "/etc/rocky/devtools/modulefiles/$module:$stream "
-                echo "Including Module: $module:$stream" >&2
-            else
-                echo "WARNING: Could not find module config for: $module:$stream" >&2
-            fi
-        fi
-    done`
-
-    rockymockgen $FILES >> "$TMPCFG"
-
-    sleep 3
-fi
-
-echo "MOCKCFG=$TMPCFG"
+# Module builds not supported. Use Lazybuilder or Peridot
+MOCKCONFIG="/etc/mock/rocky-${VERSION}-${ARCH}.cfg"
 
 test -d "${HOME}/rocky/builds/${NAME}/${BRANCH}" || mkdir -p "${HOME}/rocky/builds/${NAME}/${BRANCH}"
-
 set -e
 
 createrepo /usr/share/nginx/html/repo
 
-rpmbuild -bs --nodeps --define "%_topdir ${HOME}/rocky/rpms/${NAME}/${BRANCH}" --define "dist .el8" ${HOME}/rocky/rpms/${NAME}/${BRANCH}/SPECS/*.spec
+rpmbuild -bs --nodeps --define "%_topdir ${HOME}/rocky/rpms/${NAME}/${BRANCH}" --define "dist .el${VERSION}" ${HOME}/rocky/rpms/${NAME}/${BRANCH}/SPECS/*.spec
 
-mock -r "$TMPCFG" --resultdir="${HOME}/rocky/builds/${NAME}/${BRANCH}" ${HOME}/rocky/rpms/${NAME}/${BRANCH}/SRPMS/*.src.rpm --isolation=simple --cleanup-after ${MOCKARGS:-}
 
-cp ${HOME}/rocky/builds/${NAME}/${BRANCH}/*.rpm ${HOME}/rocky/rpms/${NAME}/${BRANCH}/SRPMS/*.src.rpm /usr/share/nginx/html/repo/
+DEFAULTMOCKARGS="--cleanup-after"
 
-createrepo /usr/share/nginx/html/repo
+mock -r "$MOCKCONFIG" --resultdir="${HOME}/rocky/builds/${NAME}/${BRANCH}" ${HOME}/rocky/rpms/${NAME}/${BRANCH}/SRPMS/*.src.rpm --isolation=simple ${MOCKARGS:-$DEFAULTMOCKARGS}
+
+if [[ ! -d /artifacts ]]; then 
+  mkdir /artifacts
+fi
+
+cp ${HOME}/rocky/builds/${NAME}/${BRANCH}/*.rpm ${HOME}/rocky/rpms/${NAME}/${BRANCH}/SRPMS/*.src.rpm /artifacts
+
+createrepo /artifacts
 
 if [ -n "$TMPCFG" ]; then
     rm "$TMPCFG"

--- a/bin/rockyget
+++ b/bin/rockyget
@@ -1,11 +1,13 @@
 #!/bin/sh
 
-NAME="$1"
+NAME="${1:-$PACKAGE}"
+BRANCH="${2:-r8}"
 
 set -e
 
 if [ -z "${NAME}" ]; then
-    echo "usage: rockyget NAME"
+    echo "usage: rockyget NAME [BRANCH]"
+    echo "BRANCH (r8, r9) implies VERSION (8,9)"
     exit 1
 fi
 
@@ -13,16 +15,38 @@ if [[ "${NAME}" =~ ^rocky- ]]; then
     AARGS='--import-branch-prefix=r --rpm-prefix=https://git.rockylinux.org/original/rpms'
 fi
 
-if [ -d "${HOME}/rocky/patch/${NAME}.git" ]; then
-    echo "NOTICE: Will merge local configs into pulled package"
-    ( cd "${HOME}/rocky/patch/${NAME}.git"; git add .; git commit -m "update" ) ||:
+CDN_URL="https://rocky-linux-sources-staging.a1.rockylinux.org"
+
+if [[ $BRANCH =~ 9 ]]; then
+	CDN_URL="https://sources.build.resf.org"
+fi
+
+PATCHPATH=${HOME}/rocky/patch/${NAME}.git
+if [ ! -d "${PATCHPATH}" ]; then
+    echo "Trying to clone existing patch repo"
+    if curl -sI https://git.rockylinux.org/staging/patch/${NAME} | grep "HTTP/1.1 200 OK" >/dev/null 2>&1; then # if it's a real repo
+        echo "Found existing patch repo. Cloning to ${PATCHPATH}"
+    	git clone --branch ${BRANCH} https://git.rockylinux.org/staging/patch/${NAME}.git "${PATCHPATH}" ||:
+    else
+        echo "No patch repo exists. Initing empty"
+        git init ${PATCHPATH}
+        git -C ${PATCHPATH} checkout -b ${BRANCH} 
+        git -C ${PATCHPATH} commit --allow-empty -m 'Initial commit' 
+        git -C ${PATCHPATH} remote add origin https://git.rockylinux.org/staging/patch/${NAME}.git
+    fi
 fi
 
 test -d "$HOME/rocky/rpms/${NAME}" && rm -rf "$HOME/rocky/rpms/${NAME}"
 test -d /tmp/srpmproc-cache || mkdir /tmp/srpmproc-cache
 mkdir -p "$HOME/rocky/rpms/${NAME}"
 
-srpmproc --version 8 --upstream-prefix "file://$HOME/rocky" --storage-addr file:///tmp/srpmproc-cache --source-rpm "$NAME" --tmpfs-mode "$HOME/rocky/rpms/${NAME}" ${AARGS}
+if [[ ! -f $HOME/.ssh/id_rsa ]]; then
+  ssh-keygen -t rsa -q -f "$HOME/.ssh/id_rsa" -N ""
+fi
+
+pushd $HOME/rocky/rpms/ >/dev/null
+srpmproc --cdn-url $CDN_URL  --version ${BRANCH:1:1} --upstream-prefix "file://$HOME/rocky" --storage-addr file:///tmp/srpmproc-cache --source-rpm "$NAME" --tmpfs-mode "${NAME}" ${AARGS}
+popd >/dev/null
 
 echo "Package has been pulled to: $HOME/rocky/rpms/${NAME}"
 echo

--- a/bin/rockymkcfg
+++ b/bin/rockymkcfg
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-NAME="$1"
+NAME="${1:-$PACKAGE}"
 
 if [ -z "$NAME" ]; then
     echo "USAGE: $0 [PACKAGE NAME]"
@@ -18,7 +18,7 @@ mkdir -p "$HOME/rocky/patch/${NAME}.git/ROCKY/CFG"
 mkdir -p "$HOME/rocky/patch/${NAME}.git/ROCKY/_supporting"
 cd "$HOME/rocky/patch/${NAME}.git"
 git init
-git checkout -b main
+git checkout -b ${BRANCH}
 
 echo "Rocky patch directory created for package '${NAME}' and can be found in:"
 echo "   $HOME/rocky/patch/${NAME}.git"

--- a/bin/rockypatch
+++ b/bin/rockypatch
@@ -2,7 +2,7 @@
 
 set -e
 
-ARCH=`uname -m`
+ARCH=${ARCH:-$(uname -m)}
 
 NAME=`pwd | sed -e "s@^$HOME/rocky/_work/@@" | awk -F '/' '{print $1}'`
 BRANCH=`pwd | sed -e "s@^$HOME/rocky/_work/@@" | awk -F '/' '{print $2}'`

--- a/bin/rockyprep
+++ b/bin/rockyprep
@@ -1,22 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-ARCH=`uname -m`
-NAME="$1"
-BRANCH="$2"
+NAME="${1:-$PACKAGE}"
+BRANCH="${2:-${BRANCH:-r8}}"
+ARCH=${ARCH:-$(uname -m)}
+VERSION="${BRANCH:1:1}"
 
 if [ -z "$NAME" ]; then
     echo "USAGE: $0 [PACKAGE NAME] [BRANCH]"
     exit 1
-else
-    shift
-fi
-
-if [ -z "$BRANCH" ]; then
-    BRANCH="r8"
-else
-    shift
 fi
 
 if [ ! -d "${HOME}/rocky/rpms/${NAME}" ]; then
@@ -33,14 +26,8 @@ fi
 test -d "${HOME}/rocky/_work/${NAME}/${BRANCH}" && rm -rf "${HOME}/rocky/_work/${NAME}/${BRANCH}"
 mkdir -p "${HOME}/rocky/_work/${NAME}/${BRANCH}"
 
-if [ ! -d "$HOME/rocky/patch/${NAME}.git/ROCKY/CFG" ]; then
-    mkdir -p "$HOME/rocky/patch/${NAME}.git/ROCKY/CFG"
-    mkdir -p "$HOME/rocky/patch/${NAME}.git/ROCKY/_supporting"
-    ( cd "$HOME/rocky/patch/${NAME}.git" && git init && git checkout -b main )
-fi
-
-
-rpmbuild -bp --nodeps --define "%_topdir ${HOME}/rocky/rpms/${NAME}/${BRANCH}" --define "_builddir ${HOME}/rocky/_work/${NAME}/${BRANCH}" --define "dist .el8" ${HOME}/rocky/rpms/${NAME}/${BRANCH}/SPECS/*.spec
+rpmbuild -bp --nodeps --define "%_topdir ${HOME}/rocky/rpms/${NAME}/${BRANCH}" --define "_builddir ${HOME}/rocky/_work/${NAME}/${BRANCH}" --define "dist .el${VERSION}" ${HOME}/rocky/rpms/${NAME}/${BRANCH}/SPECS/*.spec
 
 echo "Created ${HOME}/rocky/_work/${NAME}/${BRANCH}/"
+
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+ctrl_c(){
+  echo "***Trapped ^C. Terminating"
+  exit 2
+}
+
+trap ctrl_c SIGINT
+
+export PATH="/usr/local/bin/:$PATH"
+
+actions=( $@ )
+for action in "${actions[@]}"; do
+    printf "[ action: %s ]\n" "$action"
+    case $action in
+        get)    rockyget ;; 
+       prep)    rockyprep ;; 
+      build)    rockybuild ;; 
+          *)    printf "unsupported action: %s\n" "$action";;
+    esac
+done

--- a/etc_mock/rocky-8-aarch64.cfg
+++ b/etc_mock/rocky-8-aarch64.cfg
@@ -1,0 +1,5 @@
+include('templates/rocky-8.tpl')
+
+config_opts['root'] = 'rocky-8-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/etc_mock/rocky-8-x86_64.cfg
+++ b/etc_mock/rocky-8-x86_64.cfg
@@ -1,0 +1,5 @@
+include('templates/rocky-8.tpl')
+
+config_opts['root'] = 'rocky-8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/etc_mock/rocky-9-x86_64.cfg
+++ b/etc_mock/rocky-9-x86_64.cfg
@@ -1,0 +1,152 @@
+################################################################################
+# Mock defaults
+config_opts['root'] = 'rocky-9-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64', 'noarch')
+config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep '
+config_opts['dist'] = 'el9'
+config_opts['releasever'] = '9'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+
+################################################################################
+# Mimicking some build options
+config_opts['plugin_conf']['ccache_enable'] = False
+config_opts['plugin_conf']['root_cache_enable'] = False
+config_opts['plugin_conf']['yum_cache_enable'] = False
+config_opts['rpmbuild_networking'] = False
+config_opts['use_host_resolv'] = False
+config_opts['macros']['%_rpmfilename'] = '%%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm'
+config_opts['macros']['%_host'] = 'x86_64-redhat-linux-gnu'
+config_opts['macros']['%_host_cpu'] = 'x86_64'
+config_opts['macros']['%_vendor'] = "redhat"
+config_opts['macros']['%_vendor_host'] = "redhat"
+config_opts['macros']['%dist'] = '.el9'
+
+################################################################################
+# Start specific macros for builds
+config_opts['macros']['%vendor'] = "Rocky"
+config_opts['macros']['%packager'] = "Lazy Builder <releng@rockylinux.org>"
+
+################################################################################
+# Start options for detailed information in results
+config_opts['plugin_conf']['showrc_enable'] = True
+config_opts['plugin_conf']['package_state_enable'] = True
+config_opts['plugin_conf']['package_state_opts'] = {}
+config_opts['plugin_conf']['package_state_opts']['available_pkgs'] = False
+config_opts['plugin_conf']['package_state_opts']['installed_pkgs'] = True
+
+################################################################################
+# Planned section for extra options
+# End
+################################################################################
+
+################################################################################
+# Modules, if required will be in this section
+# End
+################################################################################
+
+
+#config_opts['nspawn_args'] = ['--system-call-filter=clone3  --capability=all']
+#config_opts['nspawn_args'] = ['--resolv-conf=copy-host']
+
+
+config_opts['dnf.conf'] = """
+[main]
+cachedir=/var/cache/yum
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+protected_packages=
+module_platform_id=platform:el9
+
+exclude=
+
+[baseos]
+name=baseos
+baseurl=http://ftp.redhat.com/redhat/rhel/rhel-9-beta/baseos/x86_64/
+gpgcheck=0
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-9
+priority=50
+module_hotfixes=0
+exclude=redhat-release*,centos-release*
+
+[appstream]
+name=appstream
+baseurl=http://ftp.redhat.com/redhat/rhel/rhel-9-beta/appstream/x86_64/
+gpgcheck=0
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-9
+priority=50
+module_hotfixes=0
+
+[crb]
+name=crb
+baseurl=http://ftp.redhat.com/redhat/rhel/rhel-9-beta/codeready-builder/x86_64/
+gpgcheck=0
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-9
+priority=50
+module_hotfixes=0
+
+[ha]
+name=ha
+baseurl=http://ftp.redhat.com/redhat/rhel/rhel-9-beta/add-ons/highavailability/x86_64/
+gpgcheck=0
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-9
+priority=50
+module_hotfixes=0
+
+[rs]
+name=rs
+baseurl=http://ftp.redhat.com/redhat/rhel/rhel-9-beta/add-ons/resilientstorage/x86_64/
+gpgcheck=0
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-9
+priority=50
+module_hotfixes=0
+
+
+# The idea is that if we have a bootstrap repo, regardless of where it's at, it
+# will need to be placed here with gpg check off. The packages don't get signed
+# during a bootstrap anyway
+
+[rocky9_stage1_bootstrap]
+name=rocky9_stage1_bootstrap
+baseurl=https://bootstrap9.releng.rockylinux.org/repos_stage1/9-lazystrap-x86_64/
+gpgcheck=0
+enabled=1
+priority=10
+module_hotfixes=0
+
+[9-binary-bootstrap]
+name=9-binary-bootstrap
+baseurl=https://bootstrap9.releng.rockylinux.org/repos_stage1/9-binary-bootstrap/
+gpgcheck=0
+enabled=1
+priority=90
+module_hotfixes=0
+
+#[bootstrap-lazystrap]
+#name=bootstrap-lazystrap
+#baseurl=file:///opt/repo/9-lazystrap-ppc64le
+#enabled=1
+#gpgcheck=0
+#priority=10
+#module_hotfixes=0
+
+
+
+"""

--- a/etc_mock/templates/rocky-8.tpl
+++ b/etc_mock/templates/rocky-8.tpl
@@ -1,0 +1,194 @@
+config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
+config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '8'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'quay.io/rockylinux/rockylinux:8'
+config_opts['external_buildrequires'] = 1
+
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+install_weak_deps=0
+protected_packages=
+module_platform_id=platform:el8
+user_agent={{ user_agent }}
+
+# Primary
+[baseos]
+name=Rocky Linux $releasever - BaseOS
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[appstream]
+name=Rocky Linux $releasever - AppStream
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[powertools]
+name=Rocky Linux $releasever - PowerTools
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=PowerTools-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/PowerTools/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[extras]
+name=Rocky Linux $releasever - Extras
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/extras/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[ha]
+name=Rocky Linux $releasever - HighAvailability
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/HighAvailability/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[resilient-storage]
+name=Rocky Linux $releasever - ResilientStorage
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/ResilientStorage/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[plus]
+name=Rocky Linux $releasever - Plus
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=rockyplus-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/plus/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[devel]
+name=Rocky Linux $releasever - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=Devel-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+# Debuginfo
+[baseos-debug]
+name=Rocky Linux $releasever - BaseOS - Debuginfo
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[appstream-debug]
+name=Rocky Linux $releasever - AppStream - Debuginfo
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[ha-debug]
+name=Rocky Linux $releasever - High Availability - Debuginfo
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/HighAvailability/$basearch/debug/tree
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[powertools-debug]
+name=Rocky Linux $releasever - PowerTools - Debuginfo
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=PowerTools-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/PowerTools/$basearch/debug/tree
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[resilient-storage-debug]
+name=Rocky Linux $releasever - Resilient Storage - Debuginfo
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/ResilientStorage/$basearch/debug/tree
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[devel-debug]
+name=Rocky Linux $releasever - Devel - Debuginfo
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=Devel-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/$basearch/debug/tree
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+# Source Repos
+[baseos-source]
+name=Rocky Linux $releasever - BaseOS - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=BaseOS-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/source/tree
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[appstream-source]
+name=Rocky Linux $releasever - AppStream - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=AppStream-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/source/tree
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[ha-source]
+name=Rocky Linux $releasever - High Availability - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=HighAvailability-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/HighAvailability/source/tree
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[powertools-source]
+name=Rocky Linux $releasever - PowerTools - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=PowerTools-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/PowerTools/source/tree
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[resilient-storage-source]
+name=Rocky Linux $releasever - Resilient Storage - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=ResilientStorage-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/ResilientStorage/source/tree
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+[devel-source]
+name=Rocky Linux $releasever - Devel - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=Devel-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/source/tree
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+
+
+"""


### PR DESCRIPTION
* Remove templates in favor of using mock templates shipped with
* Rework tools to use environment variables, when available.
* MVP containerfile that can be used to build a container to run a build in, applying patches on the way
* add some docs